### PR TITLE
Run bump version workflow before merge

### DIFF
--- a/.github/workflows/bump-too-many-hooks-version.yml
+++ b/.github/workflows/bump-too-many-hooks-version.yml
@@ -1,9 +1,8 @@
 name: Bump `too-many-hooks` version
 on:
- pull_request:
+  push:
     branches:
       - main
-    types: [labeled, unlabeled, opened, edited, reopened, synchronize, ready_for_review]
     paths:
       - 'src/hooks/**/use*.ts'
       - 'src/index.ts'
@@ -13,8 +12,8 @@ jobs:
     name: Bump and Tag Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jefflinse/pr-semver-bump@v1
+      - uses: actions/checkout@v4
+      - uses: jefflinse/pr-semver-bump@v1.6.0
         id: semver-bump
         name: Bump and Tag Version
         with:
@@ -38,11 +37,9 @@ jobs:
         with:
           commit-message: Bump package version
           branch: create-pull-request/bump-version
-          base: origin/main
           delete-branch: true
           title: Bump `too-many-hooks` version to `${{ steps.semver-bump.outputs.version }}`
           labels: documentation
-          reviewers: patrickdevries
           body: |
             Bumps from `${{ steps.semver-bump.outputs.old-version }}` to `${{ steps.semver-bump.outputs.version }}`
             Includes PRs:

--- a/.github/workflows/bump-too-many-hooks-version.yml
+++ b/.github/workflows/bump-too-many-hooks-version.yml
@@ -1,8 +1,9 @@
 name: Bump `too-many-hooks` version
 on:
-  push:
+ pull_request:
     branches:
       - main
+    types: [labeled, unlabeled, opened, edited, reopened, synchronize, ready_for_review]
     paths:
       - 'src/hooks/**/use*.ts'
       - 'src/index.ts'

--- a/.github/workflows/bump-too-many-hooks-version.yml
+++ b/.github/workflows/bump-too-many-hooks-version.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           commit-message: Bump package version
           branch: create-pull-request/bump-version
+          base: main
           delete-branch: true
           title: Bump `too-many-hooks` version to `${{ steps.semver-bump.outputs.version }}`
           labels: documentation

--- a/.github/workflows/bump-too-many-hooks-version.yml
+++ b/.github/workflows/bump-too-many-hooks-version.yml
@@ -38,10 +38,11 @@ jobs:
         with:
           commit-message: Bump package version
           branch: create-pull-request/bump-version
-          base: main
+          base: origin/main
           delete-branch: true
           title: Bump `too-many-hooks` version to `${{ steps.semver-bump.outputs.version }}`
           labels: documentation
+          reviewers: patrickdevries
           body: |
             Bumps from `${{ steps.semver-bump.outputs.old-version }}` to `${{ steps.semver-bump.outputs.version }}`
             Includes PRs:

--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "NEEDS_CHECK=${{ fromJSON(env.IS_LABELED_RELEASE) || !fromJSON(env.IS_LABELED_NON_LOGICAL) }}" >> "$GITHUB_OUTPUT"
       - name: 'Checkout'
         if: ${{ fromJSON(steps.if.outputs.NEEDS_CHECK) }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'Validate Pull Request Metadata'
         if: ${{ fromJSON(steps.if.outputs.NEEDS_CHECK) }}
         uses: jefflinse/pr-semver-bump@v1.6.0

--- a/.github/workflows/validate-pr-release-info.yml
+++ b/.github/workflows/validate-pr-release-info.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
       - name: 'Validate Pull Request Metadata'
         if: ${{ fromJSON(steps.if.outputs.NEEDS_CHECK) }}
-        uses: jefflinse/pr-semver-bump@v1
+        uses: jefflinse/pr-semver-bump@v1.6.0
         with:
           mode: validate
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/hooks/UseArray/useArray.ts
+++ b/src/hooks/UseArray/useArray.ts
@@ -23,6 +23,7 @@ export type UseArrayReturn<T> = [
      *
      * @type {() => void}
      */
+
     readonly clear: () => void
     /**
      * Resets the array to its initial value

--- a/src/hooks/UseArray/useArray.ts
+++ b/src/hooks/UseArray/useArray.ts
@@ -23,7 +23,6 @@ export type UseArrayReturn<T> = [
      *
      * @type {() => void}
      */
-
     readonly clear: () => void
     /**
      * Resets the array to its initial value


### PR DESCRIPTION
### Why:

Workflow is failing due to an outdated version being picked up by GitHub actions due to the package's v1 tag not being updated

### What's being changed (if available, include any code snippets, screenshots, or gifs):

- Bump versions for pr-semver-bump 
- Bump versions for checkout in semver workflows